### PR TITLE
Added privateMediaViewer(insta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 </table>
 <p>Resources</p>
 <ul>
+  <li><a href="https://github.com/obitouka/privateMediaViewer/">Private Media Viewer</a></li>Views Instagram private/public accounts collaborated media without login.
   <li><a href="https://codeofaninja.com/tools/find-instagram-user-id/">Codeofaninja</a></li>Easy way for developers and designers to get Instagram account numeric ID by username.
   <li><a href="https://downloadgram.app/">Download Gram</a></li>Instagram downloader tool, it helps you to download Instagram photos and videos.
   <li><a href="https://dumpoir.com/">Dumpoir</a></li>Instagram story viewer anonymously - Online view profiles, reels, stories IG, followers, tagged posts.


### PR DESCRIPTION
Tool Name: privateMediaViewer

Description:
A Python script to fetch media links from private/public Instagram profiles, only if the posts are collaborative (no login required). It uses public API endpoints and respects privacy and platform limitations.

Why it's awesome:

    Requires no authentication

    Extracts collaborative posts only (respects Instagram's privacy model)

    Useful for OSINT investigations and social media monitoring

Repo Link: https://github.com/obitouka/privateMediaViewer

Let me know if this fits under a better category or if changes are needed. Thanks!