### PR TITLE
Add PeekVault to Twitter X resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Please bear in mind that changes to X, especially involving their API (March 202
  <li><a href="https://github.com/claromes/waybacktweets">Claromes</a></li>Find archived tweets on Wayback Machine in an easy way.
  <li><a href="https://codeofaninja.com/tools/find-twitter-id/">Codeofaninja</a></li>Easy way for you to get a Twitter profile's numeric ID.
  <li><a href="https://cache.digitaldigging.org/">Deleted Tweet Finder</a></li>Search for deleted tweets across multiple archival services.
+ <li><a href="https://peekvault.com/">PeekVault</a></li>Search public X/Twitter captures from the Internet Archive CDX index, preview archived snapshots, and export results.
  <li><a href="https://followerwonk.com/">Followerwonk</a></li>Twitter analytics tool used to find, analyze, and optimize for social growth and helps to explore and grow user's social graph.
  <li><a href="https://hashatit.com/">Hash At It</a></li>Hashtag search engine. *Currently Not Returning Twiiter Hashtags*
  <li><a href="https://instalker.org/">Instalker</a></li>Tracks Twitter trends, finds the most popular Twitter users, hashtags and places.
@@ -490,7 +491,6 @@ Please bear in mind that changes to X, especially involving their API (March 202
 </div>
 
   
-
 
 
 


### PR DESCRIPTION
Hi, thanks for maintaining this OSINT resource list.

This PR adds [PeekVault](https://peekvault.com/) to the Twitter X resources section. It helps search public X/Twitter captures using the Internet Archive CDX index, preview archived snapshots, and export results for review or documentation.

I placed it near the existing archive / deleted tweet tools.